### PR TITLE
Add unit tests for selenium-webdriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ https://aws.amazon.com/what-is/unit-testing/
 - Webscrcapping
 - Test websites
 - [Working with Metamask](<https://github.com/Popinek/connectWithMetamask/blob/master/main.py>)
+
+# Unit Tests for Selenium WebDriver
+
+This repository includes unit tests for Selenium WebDriver using various testing frameworks:
+
+- **xUnit**: [xunit_tests.py](tests/xunit_tests.py)
+- **MSTest**: [mstest_tests.cs](tests/mstest_tests.cs)
+- **Cypress**: [cypress_tests.js](tests/cypress_tests.js)
+- **Enzyme**: [enzyme_tests.js](tests/enzyme_tests.js)

--- a/tests/cypress_tests.js
+++ b/tests/cypress_tests.js
@@ -1,0 +1,15 @@
+describe('Selenium WebDriver Tests', () => {
+    beforeEach(() => {
+        cy.visit('https://www.google.com');
+    });
+
+    it('should perform a Google search', () => {
+        cy.get('input[name="q"]').type('OpenAI{enter}');
+        cy.title().should('include', 'OpenAI');
+    });
+
+    it('should check the page title', () => {
+        cy.visit('https://www.example.com');
+        cy.title().should('eq', 'Example Domain');
+    });
+});

--- a/tests/enzyme_tests.js
+++ b/tests/enzyme_tests.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import App from '../src/App';
+
+describe('Selenium WebDriver Tests', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = shallow(<App />);
+    });
+
+    it('should perform a Google search', () => {
+        const searchBox = wrapper.find('input[name="q"]');
+        searchBox.simulate('change', { target: { value: 'OpenAI' } });
+        searchBox.simulate('keyDown', { key: 'Enter' });
+        expect(wrapper.find('title').text()).toContain('OpenAI');
+    });
+
+    it('should check the page title', () => {
+        wrapper.setProps({ url: 'https://www.example.com' });
+        expect(wrapper.find('title').text()).toBe('Example Domain');
+    });
+});

--- a/tests/mstest_tests.cs
+++ b/tests/mstest_tests.cs
@@ -1,0 +1,41 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+namespace SeleniumWebDriverTests
+{
+    [TestClass]
+    public class SeleniumWebDriverTests
+    {
+        private IWebDriver driver;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            driver = new ChromeDriver();
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            driver.Quit();
+        }
+
+        [TestMethod]
+        public void TestGoogleSearch()
+        {
+            driver.Navigate().GoToUrl("https://www.google.com");
+            var searchBox = driver.FindElement(By.Name("q"));
+            searchBox.SendKeys("OpenAI");
+            searchBox.SendKeys(Keys.Enter);
+            Assert.IsTrue(driver.Title.Contains("OpenAI"));
+        }
+
+        [TestMethod]
+        public void TestPageTitle()
+        {
+            driver.Navigate().GoToUrl("https://www.example.com");
+            Assert.AreEqual("Example Domain", driver.Title);
+        }
+    }
+}

--- a/tests/xunit_tests.py
+++ b/tests/xunit_tests.py
@@ -1,0 +1,25 @@
+import unittest
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+
+class TestSeleniumWebDriver(unittest.TestCase):
+
+    def setUp(self):
+        self.driver = webdriver.Chrome()
+
+    def tearDown(self):
+        self.driver.quit()
+
+    def test_google_search(self):
+        self.driver.get("https://www.google.com")
+        search_box = self.driver.find_element_by_name("q")
+        search_box.send_keys("OpenAI")
+        search_box.send_keys(Keys.RETURN)
+        self.assertIn("OpenAI", self.driver.title)
+
+    def test_page_title(self):
+        self.driver.get("https://www.example.com")
+        self.assertEqual(self.driver.title, "Example Domain")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add unit tests for Selenium WebDriver using various testing frameworks.

* **xUnit**: Add `tests/xunit_tests.py` with unit tests for Selenium WebDriver using xUnit.
* **MSTest**: Add `tests/mstest_tests.cs` with unit tests for Selenium WebDriver using MSTest.
* **Cypress**: Add `tests/cypress_tests.js` with unit tests for Selenium WebDriver using Cypress.
* **Enzyme**: Add `tests/enzyme_tests.js` with unit tests for Selenium WebDriver using Enzyme.
* **README.md**: Add a section about unit tests for Selenium WebDriver, mentioning the use of xUnit, MSTest, Cypress, and Enzyme, and provide links to the test files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ewdlop/UnitTesting-Note/pull/1?shareId=51a2ef95-64e9-49d2-9e2c-64a69596992d).